### PR TITLE
Docker: remove need for sudo, make image lookup more specific

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,8 +15,8 @@ IMAGE_NAME="yocto-librescoot:${COMMIT_ID}"
 
 mkdir -p yocto
 
-if ! docker images | grep -q "${COMMIT_ID}"; then
-    echo "Building Docker image ${IMAGE_NAME}..."
+if ! docker images "${IMAGE_NAME}" | grep -q "${COMMIT_ID}"; then
+    echo "Docker image ${IMAGE_NAME} not found, building..."
     docker build \
         --build-arg UID=$(id -u) \
         --build-arg GID=$(id -g) \

--- a/build.sh
+++ b/build.sh
@@ -14,18 +14,21 @@ COMMIT_ID=$(git rev-parse --short HEAD)
 IMAGE_NAME="yocto-librescoot:${COMMIT_ID}"
 
 mkdir -p yocto
-sudo chown 999:999 yocto
 
-if ! sudo docker images | grep -q "${COMMIT_ID}"; then
+if ! docker images | grep -q "${COMMIT_ID}"; then
     echo "Building Docker image ${IMAGE_NAME}..."
-    sudo docker build -t "${IMAGE_NAME}" ./docker
+    docker build \
+        --build-arg UID=$(id -u) \
+        --build-arg GID=$(id -g) \
+        -t "${IMAGE_NAME}" \
+        ./docker
 else
     echo "Using existing Docker image ${IMAGE_NAME}."
 fi
 
 echo "Building target: ${TARGET}"
 
-sudo docker run -it --rm \
+docker run -it --rm \
     -v "$(pwd)/yocto:/yocto" \
     --name yocto-build \
     -e TARGET="${TARGET}" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:22.04
 
+ARG UID
+ARG GID
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
@@ -16,8 +19,8 @@ RUN apt-get update && apt-get install -y \
 RUN locale-gen en_US.UTF-8
 
 RUN mkdir -p /etc/sudoers.d && \
-    groupadd -g 999 yocto && \
-    useradd -m -u 999 -g 999 yocto && \
+    groupadd -g ${GID} yocto && \
+    useradd -m -u ${UID} -g ${GID} yocto && \
     usermod -aG sudo yocto && \
     echo "yocto ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/yocto
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,9 +18,10 @@ RUN apt-get update && apt-get install -y \
 
 RUN locale-gen en_US.UTF-8
 
+RUN groupadd -g ${GID} -f yocto && \
+    useradd -m -u ${UID} -g ${GID} yocto
+
 RUN mkdir -p /etc/sudoers.d && \
-    groupadd -g ${GID} yocto && \
-    useradd -m -u ${UID} -g ${GID} yocto && \
     usermod -aG sudo yocto && \
     echo "yocto ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/yocto
 

--- a/interactive.sh
+++ b/interactive.sh
@@ -4,18 +4,20 @@ COMMIT_ID=$(git rev-parse --short HEAD)
 IMAGE_NAME="yocto-librescoot:${COMMIT_ID}"
 
 mkdir -p yocto
-sudo chown 999:999 yocto
 
-if ! sudo docker images | grep -q "${COMMIT_ID}"; then
-    echo "Building Docker image ${IMAGE_NAME}..."
-    sudo docker build -t "${IMAGE_NAME}" ./docker
+if ! docker images "${IMAGE_NAME}" | grep -q "${COMMIT_ID}"; then
+    echo "Docker image ${IMAGE_NAME} not found, building..."
+    docker build \
+        --build-arg UID=$(id -u) \
+        --build-arg GID=$(id -g) \
+        -t "${IMAGE_NAME}" \
+        ./docker
 else
     echo "Using existing Docker image ${IMAGE_NAME}."
 fi
 
-sudo docker run -it --rm \
+docker run -it --rm \
     -v "$(pwd)/yocto:/yocto" \
     --name yocto-build \
     --entrypoint /bin/bash \
     "${IMAGE_NAME}"
-


### PR DESCRIPTION
Removes `sudo` calls from `docker` calls, make sure you installed Docker correctly including adding your local non-administrative user to the `docker` group as appropriate (Docker Desktop installer might do this for you, but it might also not have). For e.g. Ubuntu Linux, run `sudo usermod -G docker -a $USER` to make it work.

Additionally, changes Dockerfile to accept `UID` and `GID` build args and extends `build.sh` and `interactive.sh` to provide the correct arguments, thus ensuring the volume bind mount has the correct permissions.